### PR TITLE
Feat use full width to display card text.

### DIFF
--- a/src/components/card/card.module.css
+++ b/src/components/card/card.module.css
@@ -307,7 +307,7 @@
 }
 
 .text p {
-  max-width: 60ch;
+  max-width: 95%;
 }
 
 .text b {


### PR DESCRIPTION
BEFORE: 
<img width="1188" alt="Screenshot 2024-09-14 at 1 06 05 PM" src="https://github.com/user-attachments/assets/0cdb29dd-d01b-4751-ad5f-36d7977f9f26">

AFTER: 
<img width="1196" alt="Screenshot 2024-09-14 at 1 06 36 PM" src="https://github.com/user-attachments/assets/6d22134a-7fa2-4a3a-bbd4-0c4ee7b33f36">
