### PR TITLE
feat: deck description updates

### DIFF
--- a/src/components/card-tooltip.tsx
+++ b/src/components/card-tooltip.tsx
@@ -18,7 +18,7 @@ export function CardTooltip(props: Props) {
   if (!resolvedCard) return null;
 
   return (
-    <div className={css["tooltip"]}>
+    <div className={css["tooltip"]} data-testid="card-tooltip">
       <Card resolvedCard={resolvedCard} size="tooltip" />
     </div>
   );

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -226,6 +226,10 @@ small {
   font-size: var(--text-xs);
 }
 
+.small {
+  font-size: var(--text-xs);
+}
+
 ol,
 ul {
   padding: 0;

--- a/src/test/e2e/deck-description.spec.ts
+++ b/src/test/e2e/deck-description.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+import { importDeckFromFile } from "./actions";
+import { mockApiCalls } from "./mocks";
+
+test.beforeEach(async ({ page }) => {
+  await mockApiCalls(page);
+  await page.goto("/");
+});
+
+test.describe("deck description", () => {
+  test("redirect card links to arkham.build", async ({ page }) => {
+    await importDeckFromFile(page, "./deck_description.json", {
+      navigate: "view",
+    });
+    await page.getByTestId("tab-notes").click();
+
+    await page.getByRole("link", { name: "Colt" }).first().click();
+    await expect(page.getByTestId("card-face")).toBeVisible();
+
+    const nextPagePromise = page.waitForEvent("popup");
+    await page.getByRole("link", { name: "Colt" }).first().click();
+    const nextPage = await nextPagePromise;
+
+    const url = new URL(nextPage.url());
+    expect(url.pathname).toEqual("/card/03020");
+    expect(new URL(page.url()).origin).toEqual(url.origin);
+  });
+
+  test("redirect FAQ links to arkhamdb", async ({ page }) => {
+    await importDeckFromFile(page, "./deck_description.json", {
+      navigate: "view",
+    });
+    await page.getByTestId("tab-notes").click();
+
+    const nextPagePromise = page.waitForEvent("popup");
+    await page.getByRole("link", { name: "ruling" }).click();
+    const nextPage = await nextPagePromise;
+
+    const nextPageOrigin = new URL(nextPage.url()).origin;
+    expect(nextPageOrigin).toEqual("https://arkhamdb.com");
+  });
+
+  test("redirect other relative links to arkhamdb", async ({ page }) => {
+    await importDeckFromFile(page, "./deck_description.json", {
+      navigate: "view",
+    });
+    await page.getByTestId("tab-notes").click();
+
+    const nextPagePromise = page.waitForEvent("popup");
+    await page.getByRole("link", { name: "decklist" }).click();
+    const nextPage = await nextPagePromise;
+
+    const nextPageOrigin = new URL(nextPage.url()).origin;
+    expect(nextPageOrigin).toEqual("https://arkhamdb.com");
+  });
+
+  test("redirect card links with nested content flow content", async ({
+    page,
+  }) => {
+    await importDeckFromFile(page, "./deck_description.json", {
+      navigate: "view",
+    });
+    await page.getByTestId("tab-notes").click();
+
+    await page.getByRole("link", { name: "True Grit" }).first().click();
+    await expect(
+      page.getByTestId("card-tooltip").getByTestId("card-03021"),
+    ).toBeVisible();
+
+    const nextPagePromise = page.waitForEvent("popup");
+    await page.getByRole("link", { name: "True Grit" }).first().click();
+    const nextPage = await nextPagePromise;
+
+    const url = new URL(nextPage.url());
+    expect(url.pathname).toEqual("/card/03021");
+    expect(new URL(page.url()).origin).toEqual(url.origin);
+  });
+
+  test("redirect card links with nested block content", async ({ page }) => {
+    await importDeckFromFile(page, "./deck_description.json", {
+      navigate: "view",
+    });
+    await page.getByTestId("tab-notes").click();
+    await page
+      .getByTestId("description-content")
+      .getByRole("link", { name: "card" })
+      .click();
+
+    const nextPagePromise = page.waitForEvent("popup");
+    await page
+      .getByTestId("description-content")
+      .getByRole("link", { name: "card" })
+      .click();
+    const nextPage = await nextPagePromise;
+    const url = new URL(nextPage.url());
+    expect(url.pathname).toEqual("/card/03022");
+    expect(new URL(page.url()).origin).toEqual(url.origin);
+  });
+});

--- a/src/test/fixtures/decks/deck_description.json
+++ b/src/test/fixtures/decks/deck_description.json
@@ -1,0 +1,27 @@
+{
+  "id": "70G71LwyNSC5VRd",
+  "date_creation": "2024-12-02T11:39:07.464Z",
+  "date_update": "2024-12-02T11:43:15.710Z",
+  "description_md": "Link to a card: [.32 Colt](/card/03020)  \nLink to a ruling: [ruling](/card/60132#review-5227)  \nLink to a decklist: [decklist](/decklist/view/51880/old-yorick-shot-guns-1.0)  \nLink with nested flow content: [**True Grit**](/card/03021)  \nLink with nested image: [![card](https://assets.arkham.build/optimized/03022.avif)](/card/03022)  \n",
+  "meta": "{}",
+  "ignoreDeckLimitSlots": {},
+  "sideSlots": {},
+  "next_deck": null,
+  "previous_deck": null,
+  "tags": "",
+  "version": "0.1",
+  "taboo_id": 8,
+  "xp": null,
+  "xp_spent": null,
+  "exile_string": null,
+  "xp_adjustment": null,
+  "investigator_code": "01001",
+  "investigator_name": "Roland Banks",
+  "name": "deck notes test",
+  "slots": {
+    "01000": 1,
+    "01006": 1,
+    "01007": 1
+  },
+  "problem": "too_few_cards"
+}

--- a/src/utils/arkhamdb.ts
+++ b/src/utils/arkhamdb.ts
@@ -2,38 +2,25 @@ import type { ResolvedDeck } from "@/store/lib/types";
 
 export function redirectArkhamDBLinks(evt: React.MouseEvent) {
   evt.preventDefault();
-  const target = evt.target as HTMLElement;
 
-  /**
-   * If one clicked on bolded anchor or image anchor, need to look for `<a>` on its parent.
-   */
-  function searchForAnchorParentRecursive(
-    node: HTMLElement,
-  ): HTMLAnchorElement | null {
-    if (node instanceof HTMLAnchorElement) {
-      return node;
+  if (evt.target instanceof HTMLElement) {
+    const anchor = evt.target?.closest("a") as HTMLAnchorElement;
+
+    if (anchor != null) {
+      const href = anchor.getAttribute("href");
+      if (!href) return;
+
+      let url: string;
+      if (href.startsWith("/card")) {
+        url = href;
+      } else if (href.startsWith("/")) {
+        url = `https://arkhamdb.com${href}`;
+      } else {
+        url = href;
+      }
+
+      window.open(url, "_blank");
     }
-    if (node.parentElement) {
-      return searchForAnchorParentRecursive(node.parentElement);
-    }
-    return null;
-  }
-
-  const anchor = searchForAnchorParentRecursive(target);
-  if (anchor !== null) {
-    const href = anchor.getAttribute("href");
-    if (!href) return;
-
-    let url: string;
-    if (href.startsWith("/card")) {
-      url = href;
-    } else if (href.startsWith("/")) {
-      url = `https://arkhamdb.com${href}`;
-    } else {
-      url = href;
-    }
-
-    window.open(url, "_blank");
   }
 }
 

--- a/src/utils/arkhamdb.ts
+++ b/src/utils/arkhamdb.ts
@@ -11,7 +11,7 @@ export function redirectArkhamDBLinks(evt: React.MouseEvent) {
       if (!href) return;
 
       let url: string;
-      if (href.startsWith("/card")) {
+      if (href.startsWith("/card") && !href.includes("#review-")) {
         url = href;
       } else if (href.startsWith("/")) {
         url = `https://arkhamdb.com${href}`;

--- a/src/utils/arkhamdb.ts
+++ b/src/utils/arkhamdb.ts
@@ -2,11 +2,36 @@ import type { ResolvedDeck } from "@/store/lib/types";
 
 export function redirectArkhamDBLinks(evt: React.MouseEvent) {
   evt.preventDefault();
-  if (evt.target instanceof HTMLAnchorElement) {
-    const href = evt.target.getAttribute("href");
+  const target = evt.target as HTMLElement;
+
+  /**
+   * If one clicked on bolded anchor or image anchor, need to look for `<a>` on its parent.
+   */
+  function searchForAnchorParentRecursive(
+    node: HTMLElement,
+  ): HTMLAnchorElement | null {
+    if (node instanceof HTMLAnchorElement) {
+      return node;
+    }
+    if (node.parentElement) {
+      return searchForAnchorParentRecursive(node.parentElement);
+    }
+    return null;
+  }
+
+  const anchor = searchForAnchorParentRecursive(target);
+  if (anchor !== null) {
+    const href = anchor.getAttribute("href");
     if (!href) return;
 
-    const url = href.startsWith("/") ? `https://arkhamdb.com${href}` : href;
+    let url: string;
+    if (href.startsWith("/card")) {
+      url = href;
+    } else if (href.startsWith("/")) {
+      url = `https://arkhamdb.com${href}`;
+    } else {
+      url = href;
+    }
 
     window.open(url, "_blank");
   }


### PR DESCRIPTION
- Nested anchor still get redirected.
- Use arkham.build card page if anchor is `/card`.
- arkhamdb's `.small` style emulation.

Result after the change :

- Before : Clicking cards would go to arkhamdb.
- Before : Clicking bold link or bold card link does nothing.

<img width="843" alt="image" src="https://github.com/user-attachments/assets/75e3466f-837a-47cc-b898-f18ad24e4f3c">
