### PR TITLE
Some updates for exiled cards on deck edit

### DIFF
--- a/src/components/deck-display/deck-history/latest-upgrade.tsx
+++ b/src/components/deck-display/deck-history/latest-upgrade.tsx
@@ -81,7 +81,6 @@ export function LatestUpgrade(props: Props) {
         const slot = deck[mapTabToSlot(currentTab)];
         if (slot) {
           const result = (slot[card.code] ?? 0) < cardLimit(card);
-          console.log(slot[card.code], cardLimit(card), result);
           return result;
         }
       }

--- a/src/components/deck-display/deck-history/latest-upgrade.tsx
+++ b/src/components/deck-display/deck-history/latest-upgrade.tsx
@@ -179,7 +179,7 @@ export function LatestUpgrade(props: Props) {
                     <FlameIcon /> Exile
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent>
+                <PopoverContent onClick={(evt) => evt.stopPropagation()}>
                   <article className={css["exile"]}>
                     <header>
                       <h3>Exiled cards</h3>

--- a/src/components/deck-display/deck-history/latest-upgrade.tsx
+++ b/src/components/deck-display/deck-history/latest-upgrade.tsx
@@ -15,7 +15,7 @@ import type { ResolvedDeck } from "@/store/lib/types";
 import { selectLatestUpgrade } from "@/store/selectors/decks";
 import type { Card } from "@/store/services/queries.types";
 import { type Tab, mapTabToSlot } from "@/store/slices/deck-edits.types";
-import { isStaticInvestigator } from "@/utils/card-utils";
+import { cardLimit, isStaticInvestigator } from "@/utils/card-utils";
 import { cx } from "@/utils/cx";
 import { useAccentColor } from "@/utils/use-accent-color";
 import {
@@ -73,6 +73,21 @@ export function LatestUpgrade(props: Props) {
       );
     },
     [currentTab, deck.id, updateCardQuantity],
+  );
+
+  const canAddExile = useCallback(
+    (card: Card) => {
+      if (currentTab && currentTab !== "meta") {
+        const slot = deck[mapTabToSlot(currentTab)];
+        if (slot) {
+          const result = (slot[card.code] ?? 0) < cardLimit(card);
+          console.log(slot[card.code], cardLimit(card), result);
+          return result;
+        }
+      }
+      return false;
+    },
+    [currentTab, deck],
   );
 
   if (!latestUpgrade) return null;
@@ -196,7 +211,9 @@ export function LatestUpgrade(props: Props) {
                                 ? (card) => (
                                     <Button
                                       iconOnly
-                                      disabled={staticInvestigator}
+                                      disabled={
+                                        staticInvestigator || !canAddExile(card)
+                                      }
                                       data-testid={`latest-upgrade-exile-${code}-add`}
                                       onClick={(
                                         evt: React.MouseEvent<HTMLButtonElement>,


### PR DESCRIPTION
This PR stop propagation of clicks inside this "Exiled cards" popover from affecting expand/collapse status of the XP spent collapsible, and grey out the add exiled card back to the deck button if it can no longer be added.

<img width="727" alt="Screenshot 2567-12-15 at 19 10 12" src="https://github.com/user-attachments/assets/bafc8ca1-a6ec-4d6d-a6b3-c68988587271" />