### PR TITLE
fix: missing singular for cards and incorrect namespace for sharing tooltip

### DIFF
--- a/src/components/deck-display/sidebar.tsx
+++ b/src/components/deck-display/sidebar.tsx
@@ -590,7 +590,7 @@ function Sharing(props: { onArkhamDBUpload?: () => void; deck: ResolvedDeck }) {
                   tooltip={
                     <Trans
                       t={t}
-                      i18nKey="sharing.create_tooltip"
+                      i18nKey="deck_view.sharing.create_tooltip"
                       components={{ br: <br />, strong: <strong /> }}
                     >
                       Sharing creates a publicly accessible, read-only link to

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1031,8 +1031,9 @@
       },
       "group_by": "Gruppierung",
       "nav": {
-        "card_count": "{{count}} Karten",
         "card_count_hidden": "({{count}} ausgeblendet)",
+        "card_count_one": "{{count}} Karte",
+        "card_count_other": "{{count}} Karten",
         "display": "Anzeige",
         "display_as_detailed": "Detailliert",
         "display_as_list": "Liste",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1031,8 +1031,9 @@
       },
       "group_by": "Group by",
       "nav": {
-        "card_count": "{{count}} cards",
         "card_count_hidden": "({{count}} hidden by filters)",
+        "card_count_one": "{{count}} card",
+        "card_count_other": "{{count}} cards",
         "display": "Display",
         "display_as_detailed": "Detailed cards",
         "display_as_list": "List",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1049,7 +1049,6 @@
       },
       "group_by": "Grupuj według",
       "nav": {
-        "card_count": "{{count}} karty",
         "card_count_one": "{{count}} karta",
         "card_count_few": "{{count}} karty",
         "card_count_many": "{{count}} kart",


### PR DESCRIPTION
Fixing some issues I found during pl translation:
* `i18nKey` for sharing tooltip was missing correct namespace, and therefore was hardcoded to English,
* card count above card list was missing singular for English - adjusted Deutsch as well (leaving other locales for their natives)