### PR TITLE
fix: handle `Forbidden.` since its change with FAQ 2.4

### DIFF
--- a/src/store/lib/deck-validation.ts
+++ b/src/store/lib/deck-validation.ts
@@ -728,7 +728,7 @@ class DeckOptionsValidator implements SlotValidator {
       this.forbidden.push(card);
     } else if ((cardLevel(card) ?? 0) > 5) {
       this.forbidden.push(card);
-    } else if (card.real_text?.startsWith("Mutated. Forbidden.")) {
+    } else if (this.isForbiddenByTrait(card)) {
       this.forbidden.push(card);
       // campaign and investigator cards should not be validated against deck options.
     } else if (card.xp == null) {
@@ -738,6 +738,10 @@ class DeckOptionsValidator implements SlotValidator {
       this.cards.push(card);
       this.quantities[card.code] = quantity;
     }
+  }
+
+  isForbiddenByTrait(card: Card) {
+    return card.real_text?.includes("Forbidden.");
   }
 
   validate() {


### PR DESCRIPTION
Previously `Double or Nothing` had the tabooed text `^Mutated. Forbidden.`.  Since FAQ 2.4 this changed to `^Forbidden.` and is also the same for the newly forbidden `The Necronomicon`.