### PR TITLE
feat: filter is_upgrade and has_upgrade by deck investigator access

### DIFF
--- a/frontend/src/store/lib/buildql/fields.ts
+++ b/frontend/src/store/lib/buildql/fields.ts
@@ -206,9 +206,7 @@ const fieldDefinitions: FieldDefinition[] = [
       return Object.keys(otherLevels).some((otherCode) => {
         const otherCard = metadata.cards[otherCode];
         if (!otherCard || (otherCard.xp ?? 0) <= (card.xp ?? 0)) return false;
-        if (!deck) return true;
-        if (!accessFilter) return false;
-        return accessFilter(otherCard);
+        return accessFilter?.(otherCard) ?? true;
       });
     }),
     name: "has_upgrade",
@@ -314,9 +312,7 @@ const fieldDefinitions: FieldDefinition[] = [
       return Object.keys(otherLevels).some((otherCode) => {
         const otherCard = metadata.cards[otherCode];
         if (!otherCard || (otherCard.xp ?? 0) >= (card.xp ?? 0)) return false;
-        if (!deck) return true;
-        if (!accessFilter) return false;
-        return accessFilter(otherCard);
+        return accessFilter?.(otherCard) ?? true;
       });
     }),
     name: "is_upgrade",


### PR DESCRIPTION
When a deck is present, the is_upgrade and has_upgrade BuildQL fields
now check each candidate card against the deck investigator's access
rules, only considering cards the investigator can actually include.
When no deck is present, all cards are returned as before.

https://claude.ai/code/session_01CFHpZfj5h9WLvZcQXQat7C