### PR TITLE
Expand Spanish translations and fix en.json data

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -396,7 +396,6 @@
         "Dhole": "Dhole",
         "Dilemma": "Dilemma",
         "Dinosaur": "Dinosaur",
-        "Dionsaur": "Dionsaur",
         "Distortion": "Distortion",
         "Dormant": "Dormant",
         "Double": "Double",
@@ -691,6 +690,7 @@
       "uses": {
         "aether": "Aether",
         "ammo": "Ammo",
+        "arrow": "Arrow",
         "bounties": "Bounties",
         "brilliance": "Brilliance",
         "chances": "Chances",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -54,6 +54,12 @@
         "complete_task": "Completar tarea",
         "open_card_page": "Página de la carta",
         "reviews": "Reseñas"
+      },
+      "custom_behavior": {
+        "investigator_traits": {
+          "help": "{{card}} puede añadir un nuevo rasgo a tu carta de investigador.",
+          "title": "Elige el rasgo para el investigador"
+        }
       }
     },
     "card_view": {
@@ -68,6 +74,7 @@
         "view_backside": "Reverso",
         "who_can_take": "¿Quién puede llevar esta carta?"
       },
+      "errata_notice": "Errata ({{date}})",
       "faq": {
         "empty": "No hay entradas del FAQ disponibles.",
         "error": "Error al cargar el FAQ.",
@@ -126,7 +133,7 @@
         "Blessed and Cursed": "Bendecido y maldito",
         "Class Choice": "Elección de Clase",
         "Cursed": "Maldito",
-        "Deck Size": "Tamaño de mazo",
+        "Deck Size": "Tamaño del mazo",
         "Deck must have at least 10 skill cards.": "El mazo debe tener al menos 10 cartas de Habilidad.",
         "Fortune": "Fortuna",
         "Gambit": "Gambito",
@@ -155,6 +162,7 @@
         "You cannot have more than 5 level 0 Seeker cards": "No puedes tener más de 5 cartas de Buscador de nivel 0",
         "You cannot have more than 5 level 0 Survivor cards": "No puedes tener más de 5 cartas de Superviviente de nivel 0",
         "You cannot have more than one Covenant in your deck.": "No puedes tener más de un Acuerdo en tu mazo.",
+        "You must have at least 6 cards from each faction.": "Debes tener al menos 6 cartas de cada clase.",
         "You must have at least 7 cards from 3 different factions": "Debes tener al menos 7 cartas de 3 clases diferentes",
         "You must have at least 7 cards from each class": "Debes tener al menos 7 cartas de cada clase"
       },
@@ -189,7 +197,7 @@
       "icon_one": "icono de habilidad",
       "icon_other": "iconos de habilidad",
       "level": {
-        "base": "Nivel 0 / Null",
+        "base": "Nivel 0 / Sin nivel",
         "none": "Sin nivel",
         "upgrades": "Mejoras",
         "value": "Nivel {{level}}"
@@ -226,10 +234,11 @@
         "replacement": "Reemplazos",
         "requiredCards": "Cartas características",
         "restrictedTo": "Restringida a",
+        "sideDeckRequiredCards": "Cartas características de mazo extra",
         "specialist": "Especialista",
         "specialist_investigators": "Investigadores especialistas"
       },
-      "reset": "Limpiar",
+      "reset": "Restablecer",
       "seal": "Sello",
       "select": "Seleccionar",
       "set_as_default": "Establecer por defecto",
@@ -257,6 +266,7 @@
       "sort_asc": "Orden ascendente",
       "sort_desc": "Orden descendente",
       "specialist": "Especialista",
+      "stage": "Etapa",
       "subtype": {
         "basicweakness": "Debilidad Básica",
         "none": "Sin subtipo",
@@ -290,7 +300,7 @@
       "taboo": "Lista de Tabúes",
       "taboo_chained": "Cuesta {{xp}} puntos de experiencia adicionales.",
       "taboo_mutated": "Mutada",
-      "taboo_none": "ninguno",
+      "taboo_none": "Ninguna",
       "taboo_original_text": "Texto original de la carta",
       "taboo_unchained": "Cuesta {{xp}} puntos de experiencia menos.",
       "total": "total",
@@ -304,6 +314,7 @@
         "Act 1": "Acto 1",
         "Act 2": "Acto 2",
         "Agency": "Agencia",
+        "Alchemy": "Alquimia",
         "Alexandria": "Alejandría",
         "Allied": "Aliado",
         "Ally": "Aliado",
@@ -311,6 +322,7 @@
         "Ancient": "Antiguo",
         "Ancient One": "Primigenio",
         "Apiary": "Apiario",
+        "Apparel": "Indumentaria",
         "Arkham": "Arkham",
         "Arkham Asylum": "Manicomio Arkham",
         "Armor": "Protección",
@@ -342,6 +354,7 @@
         "Carnevale": "Carnevale",
         "Cart": "Carro",
         "Casino": "Casino",
+        "Castle": "Castillo",
         "Cave": "Cueva",
         "Central": "Central",
         "Charm": "Amuleto",
@@ -361,6 +374,7 @@
         "Conspirator": "Conspirador",
         "Construct": "Constructo",
         "Corruption": "Corrupción",
+        "Cosmos": "Cosmos",
         "Coterie": "Coterie",
         "Covenant": "Acuerdo",
         "Creature": "Criatura",
@@ -381,6 +395,7 @@
         "Developed": "Desarrollado",
         "Dhole": "Dhole",
         "Dilemma": "Dilema",
+        "Dinosaur": "Dinosaurio",
         "Distortion": "Distorsión",
         "Dormant": "Letargo",
         "Double": "Doble",
@@ -438,6 +453,7 @@
         "Haunted": "Embrujado",
         "Havana": "Habana",
         "Hazard": "Riesgo",
+        "Headwear": "Sombrero",
         "Hemlock Vale": "Valle de la Cicuta",
         "Hex": "Maleficio",
         "Hideout": "Escondite",
@@ -533,6 +549,8 @@
         "Present-Day": "Época actual",
         "Prison": "Prisión",
         "Private": "Privado",
+        "Profession": "Profesión",
+        "Prop": "Atrezo",
         "Providence": "Providence",
         "Public": "Público",
         "R'lyeh": "R'lyeh",
@@ -560,6 +578,8 @@
         "Ruins": "Ruinas",
         "Salem": "Salem",
         "Sanctum": "Santuario",
+        "Satellite": "Satélite",
+        "Saturnite": "Saturniano",
         "Scheme": "Maquinación",
         "Scholar": "Erudito",
         "Science": "Ciencia",
@@ -572,6 +592,7 @@
         "Serpent": "Serpiente",
         "Service": "Servicio",
         "Servitor": "Servidor",
+        "Set": "Plató",
         "Shantak": "Shantak",
         "Shattered": "Destrozado",
         "Ship": "Barco",
@@ -639,6 +660,7 @@
         "Witch": "Bruja",
         "Witch House": "Casa de la bruja",
         "Woods": "Bosque",
+        "Worker": "Trabajador",
         "Y'ha-nthlei": "Y'ha-nthlei",
         "Yithian": "Yithiano",
         "Yoth": "Yoth",
@@ -668,6 +690,7 @@
       "uses": {
         "aether": "Éter",
         "ammo": "Munición",
+        "arrow": "Flecha",
         "bounties": "Recompensas",
         "brilliance": "Brillo",
         "chances": "Oportunidades",
@@ -682,8 +705,11 @@
         "obsessions": "Obsesiones",
         "offerings": "Ofrendas",
         "portents": "Portentos",
+        "renown": "Renombre",
         "resources": "Recursos",
+        "rumors": "Rumores",
         "secrets": "Secretos",
+        "shards": "Fragmentos",
         "shell": "Proyectil",
         "signs": "Señales",
         "supplies": "Suministros",
@@ -716,8 +742,8 @@
         "export_json": "Exportar JSON",
         "export_text": "Exportar texto",
         "unarchive": "Desarchivar mazo",
-        "upgrade": "Mejorar mazo",
-        "upgrade_short": "Mejorar"
+        "upgrade": "Mejorar mazo (XP)",
+        "upgrade_short": "Mejorar (XP)"
       },
       "annotation": "Notas",
       "annotation_tooltip": "La carta tiene notas",
@@ -741,18 +767,19 @@
         "xp_spent": "XP gastados"
       },
       "limited_decks": {
+        "Collector": "Coleccionista",
         "Secondary Class": "Clase secundaria",
         "Versatile": "Versátil"
       },
       "limited_slots": "Espacios limitados",
       "stats": {
-        "deck_size": "Tamaño del mazo",
+        "deck_size": "Tam. del mazo",
         "ignored_one": "{{count}} copia no cuenta para el tamaño del mazo.",
         "ignored_other": "{{count}} copias no cuentan para el tamaño del mazo.",
         "unowned": "No disponible: {{count}} de {{total}} cartas",
         "uses_parallel": "Usa un lado paralelo",
-        "xp_available_help": "XP obtenido con la última mejora.",
-        "xp_required": "XP requerido",
+        "xp_available_help": "XP obtenidos con la última mejora.",
+        "xp_required": "Experiencia",
         "xp_required_help": "Cantidad de XP requerida para construir este mazo desde cero."
       },
       "tags": {
@@ -845,7 +872,8 @@
       "sealed_deck": {
         "error": "Error al obtener el mazo Sealed: {{error}}",
         "loading": "Obteniendo mazo Sealed..."
-      }
+      },
+      "title": "Crear mazo {{name}}"
     },
     "deck_edit": {
       "actions": {
@@ -870,6 +898,7 @@
       },
       "changes_restored": "Se restauraron los cambios no guardados.",
       "config": {
+        "buildql_deck_option": "Sobreescribir reglas de construcción con BuildQL",
         "card_pool": {
           "apply_environment": "Aplicar entorno {{environment}}",
           "campaign_playalong": "Campaña Colaborativa",
@@ -879,16 +908,22 @@
           "collection_help": "Establece tu <settings_link>colección</settings_link> actual como el conjunto de cartas de este mazo. Esto puede ser útil para congelar el conjunto de cartas del mazo, o para compartir un \"ajuste predefinido\" con personas que compartan una colección física.",
           "configure_environment": "Configurar entorno",
           "current": "Actual",
+          "current_faq25": "Actual (FAQ 2.5)",
           "current_faq25_help": "En el entorno Actual, los jugadores solo pueden construir mazos con cartas básicas, los cinco mazos iniciales y las tres expansiones de investigador más recientes.",
+          "current_help": "Al construir mazos en el entorno Actual, los jugadores pueden usar los siguientes productos: La caja básica de 2026, los cinco mazos de investigador, las dos expansiones de construcción de mazos publicadas más recientemente y las dos expansiones de investigador publicadas más recientemente tras la caja básica de 2026.",
           "custom": "Personalizado",
           "help": "Los Investigadores, las cartas Personales y los Apoyos de historia no se ven afectados por esta selección.",
+          "help_chapter_1": "Esto es un entorno del Capítulo 1.",
           "legacy": "Legado",
           "legacy_help": "En el entorno Legado, los jugadores pueden construir sus mazos y usar investigadores, cartas de jugador y debilidades de cualquier producto de Arkham Horror: The Card Game™. No hay ninguna restricción.",
           "limited": "Limitado",
+          "limited_faq25": "Limitado (FAQ 2.5)",
           "limited_faq25_help": "En el entorno Limitado, los jugadores solo pueden construir sus mazos con cartas del set básico, los cinco mazos iniciales y tres expansiones de investigador diferentes a su elección.",
+          "limited_help": "Al construir mazos en el entorno Limitado, los jugadores pueden usar los siguientes productos: La caja básica de 2026, los cinco mazos de investigador y tres expansiones de cartas de jugador diferentes a su elección.",
           "placeholder": "Seleccionar packs...",
           "section_title": "Ajustes del conjunto de cartas",
           "selected_cards": "Cartas seleccionadas",
+          "substitute_chapter_2_with_chapter_1": "Sustituir la caja básica y los mazos de investigador del capítulo 2 por sus equivalentes del capítulo 1",
           "title": "Limitar conjunto de cartas"
         },
         "name": "Nombre del mazo",
@@ -1015,7 +1050,7 @@
         "save_upgrade": "Guardar mejora y editar",
         "save_upgrade_close": "Guardar mejora y cerrar",
         "save_upgrade_close_short": "Guardar y cerrar",
-        "save_upgrade_short": "Mejorar",
+        "save_upgrade_short": "Mejorar y editar",
         "upload": "Subir a {{provider}}"
       },
       "connections": {
@@ -1046,6 +1081,7 @@
       "newer_version": "Hay una <a>versión más nueva</a> de este mazo. Este mazo es de sólo lectura.",
       "scans": "Imágenes",
       "sharing": {
+        "api_link": "Json API",
         "create": "Crear enlace para compartir",
         "create_failed": "Error al crear el enlace compartido: {{error}}",
         "create_tooltip": "Crea un enlace público al mazo de sólo lectura. Cualquier persona con el enlace puede ver el mazo, pero no editarlo.<br />Los enlaces compartidos se pueden eliminar en cualquier momento. Eliminar un enlace no afecta al mazo.",
@@ -1070,7 +1106,7 @@
         "great_work_status_usurped": "La gran obra será eliminada de tu mazo junto con cada una de tus cartas características. Tu investigador será reemplazado por el homúnculo.",
         "loading": "Mejorando mazo...",
         "title": "Mejorar mazo con XP",
-        "xp_gained": "XP obtenido"
+        "xp_gained": "Puntos de experiencia obtenidos"
       }
     },
     "decklists": {
@@ -1093,7 +1129,8 @@
         "name_placeholder": "Introduce un nombre (p. ej. Guía de mazo)...",
         "required_cards": "Cartas requeridas",
         "submit": "Aplicar",
-        "title": "Criterios de filtro"
+        "title": "Criterios de filtro",
+        "xp_range": "XP requeridos"
       },
       "sorting": {
         "date": "Más reciente",
@@ -1156,6 +1193,7 @@
         "card_lists": "Listas de cartas",
         "card_lists_help": "Este ajuste controla el valor por defecto del filtro \"Contenido de fans\" en las listas de cartas."
       },
+      "short_title": "Contenido fan",
       "status": {
         "alpha": "Alfa",
         "beta": "Beta",
@@ -1182,7 +1220,6 @@
       },
       "all": "Todos",
       "and": "y",
-      "locked": "Este filtro está bloqueado",
       "asset": {
         "title": "Apoyo"
       },
@@ -1232,6 +1269,7 @@
         "no_level": "Nulo",
         "title": "Nivel"
       },
+      "locked": "Este filtro está bloqueado",
       "or": "o",
       "ownership": {
         "owned": "Propiedad",
@@ -1344,6 +1382,7 @@
         "display_as_list_text": "Lista con texto",
         "display_as_scans": "Imágenes",
         "display_as_scans_grouped": "Imágenes (agrupadas)",
+        "export": "Exportar",
         "jump_to": "Ir a...",
         "list_settings": "Ajustes de lista",
         "sort": "Ordenar",
@@ -1376,9 +1415,9 @@
       "title": "¡La temporada de spoilers ha llegado!"
     },
     "rules": {
-      "title": "Referencia de reglas",
       "back_to_top": "Volver arriba",
       "search_placeholder": "Buscar palabras clave...",
+      "title": "Referencia de reglas",
       "toc": "Índice"
     },
     "search": {
@@ -1390,6 +1429,7 @@
         "create": "Crear copia de seguridad",
         "help": "Crea una copia de seguridad de tus ajustes, mazos y colección de cartas como un archivo JSON. Puedes usar este archivo para restaurar tus datos en cualquier dispositivo.",
         "help_warning": "Cuando se restaura una copia de seguridad, <strong>cualquier dato existente se sobreescribirá.</strong>",
+        "metadata_title": "Datos de la aplicación",
         "no_file_selected": "No se ha seleccionado ningún archivo",
         "restore": "Restaurar copia de seguridad",
         "restore_error": "Error al restaurar la copia de seguridad: {{error}}",
@@ -1435,7 +1475,7 @@
         "no_errors": "Sin errores",
         "provider_error": "La sincronización con {{provider}} falló: {{error}}",
         "provider_syncing": "Sincronizando {{provider}}...",
-        "reconnect": "Refrescar",
+        "reconnect": "Reconectar",
         "sync": "Sincronizar",
         "sync_all": "Sincronizar mazos de {{collectionLabels}}",
         "sync_errors": "Errores de sincronización",
@@ -1444,6 +1484,10 @@
         "title": "Cuentas conectadas",
         "user_id": "ID de Usuario",
         "username": "Nombre de usuario"
+      },
+      "developer": {
+        "dev_mode_enabled": "Activar el modo desarrollador",
+        "title": "Desarrollador"
       },
       "display": {
         "card_display": "Ajustes de visualización de cartas",


### PR DESCRIPTION
## Summary

- Expand Spanish (`es`) translations

## Changes

- `frontend/src/locales/es.json`
- `frontend/src/locales/en.json` — remove `"Dionsaur"` typo, add `"arrow"` use