### PR TITLE
Fix cthulhu_deck back_type

### DIFF
--- a/backend/src/data/card-patches/card-back-types.json
+++ b/backend/src/data/card-patches/card-back-types.json
@@ -196,57 +196,57 @@
   },
   {
     "code": "11705",
-    "back_type": "cthulhu_deck",
+    "back_type": "cthulhu",
     "patch": true
   },
   {
     "code": "11706",
-    "back_type": "cthulhu_deck",
+    "back_type": "cthulhu",
     "patch": true
   },
   {
     "code": "11707",
-    "back_type": "cthulhu_deck",
+    "back_type": "cthulhu",
     "patch": true
   },
   {
     "code": "11708",
-    "back_type": "cthulhu_deck",
+    "back_type": "cthulhu",
     "patch": true
   },
   {
     "code": "11709",
-    "back_type": "cthulhu_deck",
+    "back_type": "cthulhu",
     "patch": true
   },
   {
     "code": "11710",
-    "back_type": "cthulhu_deck",
+    "back_type": "cthulhu",
     "patch": true
   },
   {
     "code": "11711",
-    "back_type": "cthulhu_deck",
+    "back_type": "cthulhu",
     "patch": true
   },
   {
     "code": "11712",
-    "back_type": "cthulhu_deck",
+    "back_type": "cthulhu",
     "patch": true
   },
   {
     "code": "11713",
-    "back_type": "cthulhu_deck",
+    "back_type": "cthulhu",
     "patch": true
   },
   {
     "code": "11714",
-    "back_type": "cthulhu_deck",
+    "back_type": "cthulhu",
     "patch": true
   },
   {
     "code": "11715",
-    "back_type": "cthulhu_deck",
+    "back_type": "cthulhu",
     "patch": true
   }
 ]

--- a/frontend/src/utils/card-utils.ts
+++ b/frontend/src/utils/card-utils.ts
@@ -45,7 +45,7 @@ type CardBackType =
   | "card"
   | "the_longest_night"
   | "artifact"
-  | "cthulhu_deck";
+  | "cthulhu";
 
 export function cardBackType(card: Card): CardBackType {
   if (doubleSided(card)) return "card";


### PR DESCRIPTION
The cardback on CDN is called "back_cthulhu.jpg". The code was attempting to fetch the image from "back_cthulhu_deck.jpg" which was returning 404.
Either please consider merging this or renaming the file on CDN.