### PR TITLE
fix: show keybindings in shortcuts modal on touch devices

### DIFF
--- a/frontend/src/components/help-menu.tsx
+++ b/frontend/src/components/help-menu.tsx
@@ -312,7 +312,7 @@ export function HelpMenu() {
                         {shortcuts.map(({ keybind, description }) => (
                           <Fragment key={keybind}>
                             <dt className={css["shortcut-keybind"]}>
-                              <Keybind keybind={keybind} />
+                              <Keybind keybind={keybind} alwaysVisible />
                             </dt>
                             <dd className={css["shortcut-description"]}>
                               {description}

--- a/frontend/src/components/ui/hotkey.module.css
+++ b/frontend/src/components/ui/hotkey.module.css
@@ -18,6 +18,10 @@
   }
 }
 
+.keybind-always {
+  display: inline-flex;
+}
+
 .keybind svg {
   width: 1em;
 }

--- a/frontend/src/components/ui/hotkey.tsx
+++ b/frontend/src/components/ui/hotkey.tsx
@@ -10,6 +10,7 @@ import {
   SquareArrowUpIcon,
 } from "lucide-react";
 import { cloneElement } from "react";
+import { cx } from "@/utils/cx";
 import { parseHotkey } from "@/utils/use-hotkey";
 import css from "./hotkey.module.css";
 import { DefaultTooltip, type DefaultTooltipProps } from "./tooltip";
@@ -50,12 +51,19 @@ function renderKey(key: string) {
   }
 }
 
-export function Keybind(props: Pick<Props, "keybind">) {
+export function Keybind(
+  props: Pick<Props, "keybind"> & { alwaysVisible?: boolean },
+) {
   const parsed = parseHotkey(props.keybind);
   if (!parsed) return null;
 
   return (
-    <span className={css["keybind"]}>
+    <span
+      className={cx(
+        css["keybind"],
+        props.alwaysVisible && css["keybind-always"],
+      )}
+    >
       {parsed.modifiers.map((mod) => (
         <kbd key={mod}>{renderKey(mod)}</kbd>
       ))}


### PR DESCRIPTION
On iPad with Magic Keyboard, the shortcuts modal shows text descriptions but no keybinding symbols. The .keybind CSS class is hidden by default and only revealed via a (hover: hover) and (pointer: fine) media query, which excludes touch devices even when a physical keyboard is attached.

Add an alwaysVisible prop to Keybind that bypasses the media query, and use it in the shortcuts modal where keybinds should always be visible.

<img width="2752" height="1799" alt="IMG_0539" src="https://github.com/user-attachments/assets/c2c6a1f7-5c1e-4d38-9032-f2b01c30e13b" />
