### PR TITLE
fix: load exact locale so `zh-cn` resolves to Simplified Chinese

### DIFF
--- a/frontend/src/utils/arkhamdb.ts
+++ b/frontend/src/utils/arkhamdb.ts
@@ -7,8 +7,9 @@ export function localizeArkhamDBBaseUrl() {
   const baseUrl = new URL(import.meta.env.VITE_ARKHAMDB_BASE_URL);
   if (lng === "en") return baseUrl.origin;
 
-  // ArkhamDB does not support `zh-cn` yet.
-  if (lng === "zh-CN") {
+  // ArkhamDB does not support `zh-cn` yet, so route every Chinese locale
+  // (`zh`, `zh-cn`) to its `zh` subdomain.
+  if (lng.startsWith("zh")) {
     baseUrl.hostname = `zh.${baseUrl.hostname}`;
   } else {
     baseUrl.hostname = `${lng}.${baseUrl.hostname}`;

--- a/frontend/src/utils/i18n.ts
+++ b/frontend/src/utils/i18n.ts
@@ -31,7 +31,12 @@ i18n
   .use(initReactI18next)
   .init({
     fallbackLng: "en",
-    load: "languageOnly",
+    // Load the exact selected locale (e.g. `zh-cn`), not just the base language.
+    // `languageOnly` would collapse `zh-cn` -> `zh`, making the simplified locale unreachable.
+    load: "currentOnly",
+    // Keep region subtags lower-cased so they match the lower-cased locale filenames
+    // (i18next would otherwise format `zh-cn` -> `zh-CN`, which 404s on case-sensitive hosts).
+    lowerCaseLng: true,
     partialBundledLanguages: true,
     showSupportNotice: false,
     resources: {


### PR DESCRIPTION
## Problem

Selecting **简体中文 (`zh-cn`)** in the language switcher shows **Traditional** Chinese, and `zh-cn.json` is never loaded.

`i18n.ts` initializes i18next with `load: "languageOnly"`, which strips the region subtag (`zh-cn` → `zh`). Since `LOCALES` defines both `zh-cn` (Simplified) and `zh` (Traditional), **both** options resolve to `zh` and load `zh.json` (Traditional), so the Simplified bundle is unreachable. This surfaced once the `zh-cn` locale was added (#407) — `languageOnly` is incompatible with having two locales that share the same base language.

## Fix

**`utils/i18n.ts`** — load the exact selected locale instead of collapsing the region:

- `load: "currentOnly"` loads `zh-cn` as `zh-cn` (not `zh`).
- `lowerCaseLng: true` keeps the region subtag lower-cased so it matches the `zh-cn.json` filename. Without it, i18next formats `zh-cn` → `zh-CN`, which fails to resolve against the lower-cased files (Vite's dynamic-import glob is keyed by exact string, and case-sensitive hosts 404).

**`utils/arkhamdb.ts`** — `localizeArkhamDBBaseUrl` matched the previously-collapsed value `lng === "zh-CN"`. After the fix `i18n.language` is `zh-cn` / `zh`, so it now matches `lng.startsWith("zh")` to keep routing every Chinese locale to the `zh.` subdomain (behaviour unchanged).

## Verification

- `zh-cn` now loads `zh-cn.json` (Simplified); `zh` still loads `zh.json` (Traditional); all other locales unchanged.
- Users whose stored `i18nextLng` is the old `zh-CN` are normalized to `zh-cn` (backward compatible).
- `tsc --noEmit`, `biome check`, and the full test suite (560 tests) pass.
