### PR TITLE
fix: run i18n:pull clone steps with `git -C` so they work on Windows

### DIFF
--- a/frontend/scripts/i18n-pull.ts
+++ b/frontend/scripts/i18n-pull.ts
@@ -100,7 +100,7 @@ async function cloneRepo() {
   await fs.mkdir(localPath);
 
   execSync(
-    `git clone --filter=blob:none ${repo} ${localPath} && cd ${localPath} && git sparse-checkout init --cone && git sparse-checkout set assets/i18n && git checkout master`,
+    `git clone --filter=blob:none ${repo} "${localPath}" && git -C "${localPath}" sparse-checkout init --cone && git -C "${localPath}" sparse-checkout set assets/i18n && git -C "${localPath}" checkout master`,
     { stdio: "inherit" },
   );
 


### PR DESCRIPTION
## Problem

`npm run i18n:pull` is broken on Windows when the repo and the OS temp dir live on **different drives** — a very common setup (e.g. code on `D:` while `%TEMP%` is on `C:`).

`cloneRepo()` runs, via `execSync` (which uses `cmd.exe` on Windows):

```
git clone … ${localPath} && cd ${localPath} && git sparse-checkout … && git checkout master
```

In `cmd.exe`, `cd <path-on-another-drive>` **does not switch the active drive** (that needs `cd /d`). So after `cd C:\…\arkham-cards`, the shell is still on `D:\…\arkham.build`, and the following `git sparse-checkout init/set assets/i18n` + `git checkout master` run against the **arkham.build repo itself** instead of the freshly-cloned ArkhamCards repo. That silently applies a sparse-checkout to the user's own working tree (restricting it to a non-existent `assets/i18n`, i.e. removing the rest of the files from disk) and then fails on `git checkout master`.

## Fix

Use `git -C "<path>"` instead of `cd`, and quote the path:

```
git clone … "${localPath}" && git -C "${localPath}" sparse-checkout … && git -C "${localPath}" checkout master
```

`git -C` operates in the given directory regardless of the shell's cwd/drive, and quoting handles paths containing spaces. Behaviour is identical on macOS/Linux.

## Verification

Reproduced from a repo on `D:` with temp on `C:`: `cd C:\tmp\x && git rev-parse --show-toplevel` reports the **`D:` repo** (the `cd` silently failed to switch drives), whereas `git -C "C:\tmp\x" …` correctly operates in the `C:` directory.
